### PR TITLE
fix: plug fd leaks in accept and sendfile

### DIFF
--- a/tests/e2e/proactor/test_tcp.py
+++ b/tests/e2e/proactor/test_tcp.py
@@ -19,6 +19,7 @@ async def test_tcp_conmmunication(
     await proactor.connect(client_tcp_sock, address)
     incoming_client_tcp_socket, client_tcp_sock_address = await proactor.accept(server_tcp_sock)
 
+    assert not incoming_client_tcp_socket.get_inheritable()
     assert client_tcp_sock.getsockname() == client_tcp_sock_address
 
     test_messages = [

--- a/uringloop/operation.py
+++ b/uringloop/operation.py
@@ -393,8 +393,9 @@ class AcceptOperation(BaseOperation):
         if res < 0:
             fut.set_exception(get_os_error(res))
         else:
-            # TODO make sure new socket flags inheritation
-            sock = socket.fromfd(res, self.sock.family, self.sock.type, self.sock.proto)
+            # socket.fromfd would dup() the fd and leak the original one;
+            # wrap the accepted fd directly instead (same as socket.accept)
+            sock = socket.socket(self.sock.family, self.sock.type, self.sock.proto, fileno=res)
             if socket.getdefaulttimeout() is None and self.sock.gettimeout():
                 sock.setblocking(True)
             fut.set_result((sock, parse_addr(self.sock.family, self.sockaddr)))
@@ -423,6 +424,7 @@ class SendfileOperation(BaseOperation):
     p2s_user_data: int
     f2p_done: bool = False
     p2s_done: bool = False
+    pipes_closed: bool = False
 
     def get_user_data(
         self,
@@ -450,6 +452,12 @@ class SendfileOperation(BaseOperation):
             self.p2s_done = True
         else:
             raise RuntimeError(f"Unknown user_data: {user_data} is not expected.")
+        # both linked CQEs have arrived (success, failure or cancellation), so
+        # the kernel no longer references the pipe; release the fds
+        if self.f2p_done and self.p2s_done and not self.pipes_closed:
+            self.pipes_closed = True
+            os.close(self.pipe_r)
+            os.close(self.pipe_w)
 
     def all_seen(self) -> bool:
         return self.p2s_done

--- a/uringloop/proactor.py
+++ b/uringloop/proactor.py
@@ -336,7 +336,7 @@ class IoUringProactor:
             return fut
 
     def accept(self, listener: socket.socket) -> futures.Future[tuple[socket.socket, pyAddress]]:
-        flags = 0
+        flags = socket.SOCK_CLOEXEC
         sockaddr = new_writable_sockaddr(listener.family)
         request = AcceptRequest(sock=listener, sockaddr=sockaddr, flags=flags)
         user_data = self._next_user_data()


### PR DESCRIPTION
- AcceptOperation used socket.fromfd, which dup()s the accepted fd and never closes the original, leaking one fd per accepted connection. Wrap the fd directly with socket.socket(..., fileno=res), matching what socket.accept itself does.

- SendfileOperation created a pipe pair per call and never closed it. Close both ends once both linked splice CQEs have been consumed; hardlinked SQEs always produce both CQEs, including on error or cancellation, so this runs on every path.