### PR TITLE
fix: correct event-loop and proactor behavior

### DIFF
--- a/tests/unit/test_initialization.py
+++ b/tests/unit/test_initialization.py
@@ -1,0 +1,32 @@
+import pytest
+
+import uringloop.loop
+from uringloop.loop import IouringProactorEventLoop
+import uringloop.proactor
+from uringloop.proactor import IoUringProactor
+
+
+def test_proactor_finalizer_handles_queue_initialization_failure(monkeypatch):
+    def fail_queue_init(*args):
+        raise OSError("io_uring unavailable")
+
+    monkeypatch.setattr(uringloop.proactor, "io_uring_queue_init", fail_queue_init)
+    proactor = IoUringProactor.__new__(IoUringProactor)
+
+    with pytest.raises(OSError, match="io_uring unavailable"):
+        proactor.__init__()
+
+    proactor.__del__()
+
+
+def test_event_loop_finalizer_handles_proactor_initialization_failure(monkeypatch):
+    def fail_proactor_init():
+        raise OSError("io_uring unavailable")
+
+    monkeypatch.setattr(uringloop.loop, "IoUringProactor", fail_proactor_init)
+    loop = IouringProactorEventLoop.__new__(IouringProactorEventLoop)
+
+    with pytest.raises(OSError, match="io_uring unavailable"):
+        loop.__init__()
+
+    loop.__del__()

--- a/uringloop/__init__.py
+++ b/uringloop/__init__.py
@@ -2,16 +2,26 @@ __all__ = ["IoUringProactor", "IouringProactorEventLoopPolicy", "IouringProactor
 
 
 import platform
+import re
 
 from uringloop.loop import IouringProactorEventLoop, IouringProactorEventLoopPolicy
 from uringloop.proactor import IoUringProactor
 
 
+MIN_KERNEL_VERSION = (5, 19)
+
+
 def check_kernel_version():
     if platform.system() != 'Linux':
         raise RuntimeError("Only supported on Linux")
-    major, minor = map(int, platform.release().split('.')[:2])
-    if (major, minor) < (5, 15):
-        raise RuntimeError(f"Linux kernel 5.15+ required (found {major}.{minor})")
+    release = platform.release()
+    matched = re.match(r"(\d+)\.(\d+)", release)
+    if matched is None:
+        raise RuntimeError(f"Unable to parse Linux kernel version from {release!r}")
+    major, minor = int(matched.group(1)), int(matched.group(2))
+    if (major, minor) < MIN_KERNEL_VERSION:
+        raise RuntimeError(
+            f"Linux kernel {MIN_KERNEL_VERSION[0]}.{MIN_KERNEL_VERSION[1]}+ required (found {major}.{minor})"
+        )
 
 check_kernel_version()

--- a/uringloop/lib.py
+++ b/uringloop/lib.py
@@ -67,6 +67,11 @@ POLLHUP: int = lib.POLLHUP
 POLLNVAL: int = lib.POLLNVAL
 
 
+# -1 as an unsigned __u64: read/write at the file's current position
+# (kernel 5.16+); pipes and sockets ignore the offset either way
+OFFSET_CURRENT_POS: int = 0xFFFF_FFFF_FFFF_FFFF
+
+
 # Structure creation functions
 def new_io_uring() -> IoUring:
     return ffi.new("struct io_uring *")
@@ -275,15 +280,22 @@ def new_readable_sockaddr(family: socket.AddressFamily, address: pyAddress) -> A
 
 # Function wrappers with type annotations
 def io_uring_queue_init(entries: int, ring: IoUring, flags: int = 0) -> int:
-    return lib.io_uring_queue_init(entries, ring, flags)
+    res = lib.io_uring_queue_init(entries, ring, flags)
+    if res < 0:
+        raise OSError(-res, os.strerror(-res))
+    return res
 
 
 def io_uring_queue_exit(ring: IoUring) -> int:
     return lib.io_uring_queue_exit(ring)
 
 
-def io_uring_get_sqe(ring: IoUring) -> IoUringSqe:
-    return lib.io_uring_get_sqe(ring)
+def io_uring_get_sqe(ring: IoUring) -> IoUringSqe | None:
+    """Returns None when the submission queue is full."""
+    sqe = lib.io_uring_get_sqe(ring)
+    if sqe == ffi.NULL:
+        return None
+    return sqe
 
 
 def io_uring_prep_send(sqe: IoUringSqe, request: SendRequest) -> None:

--- a/uringloop/loop.py
+++ b/uringloop/loop.py
@@ -24,7 +24,7 @@ class _IouringWritePipeTransport(proactor_events._ProactorBaseWritePipeTransport
             # the transport has been closed
             return
         poll_mask = fut.result()
-        assert (poll_mask | POLLHUP) or (poll_mask | POLLERR)
+        assert poll_mask & (POLLHUP | POLLERR)
         if self._closing:
             assert self._read_fut is None
             return
@@ -40,6 +40,9 @@ class IouringProactorEventLoop(proactor_events.BaseProactorEventLoop):
     """Linux version of proactor event loop using Iouring."""
 
     def __init__(self, proactor: IoUringProactor | None = None):
+        # BaseEventLoop.__del__ may run when constructing the default proactor
+        # fails before the base initializer has set this field.
+        self._closed = True
         if proactor is None:
             proactor = IoUringProactor()
         super().__init__(proactor)
@@ -58,10 +61,12 @@ class IouringProactorEventLoop(proactor_events.BaseProactorEventLoop):
             self._self_reading_future = None
 
     async def sock_sendall(self, sock: socket.socket | io.IOBase, data: Buffer):
-        total_length: int = len(memoryview(data))
-        while total_length > 0:
-            sent = await self._proactor.send(sock, data)
-            total_length -= sent
+        view = memoryview(data).cast("B")
+        while len(view) > 0:
+            sent = await self._proactor.send(sock, view)
+            # a partial send must continue after the sent bytes, not resend
+            # the whole buffer from the start
+            view = view[sent:]
         return
 
     async def create_unix_connection(
@@ -247,14 +252,20 @@ class UnixProactorPidfdChildWatcher(unix_events.AbstractChildWatcher):
 
         def _do_wait(fut: futures.Future[int]):
             try:
-                _, status = os.waitpid(pid, 0)
-            except ChildProcessError:
-                returncode = 255
-                logger.warning("child process pid %d exit status already read:  will report returncode 255", pid)
-            else:
-                returncode = unix_events.waitstatus_to_exitcode(status)
+                if fut.cancelled():
+                    # the poll was cancelled (e.g. loop shutdown) so the child
+                    # may still be running; waitpid would block the event loop
+                    return
+                try:
+                    _, status = os.waitpid(pid, 0)
+                except ChildProcessError:
+                    returncode = 255
+                    logger.warning("child process pid %d exit status already read:  will report returncode 255", pid)
+                else:
+                    returncode = os.waitstatus_to_exitcode(status)
+            finally:
+                os.close(pidfd)
 
-            os.close(pidfd)
             callback(pid, returncode, *args)
 
         fut.add_done_callback(_do_wait)

--- a/uringloop/operation.py
+++ b/uringloop/operation.py
@@ -11,7 +11,7 @@ from uringloop.lib import parse_addr
 
 
 if TYPE_CHECKING:
-    from proactor import _IoUringFuture  # type: ignore[reportPrivateUsage]
+    from uringloop.proactor import _IoUringFuture  # type: ignore[reportPrivateUsage]
 
 
 @dataclass(slots=True)

--- a/uringloop/proactor.py
+++ b/uringloop/proactor.py
@@ -14,6 +14,7 @@ from weakref import WeakSet
 from uringloop._types import IoUring, IoUringCqe, Sockaddr, pyAddress
 from uringloop.lib import (
     IOSQE_IO_HARDLINK,
+    OFFSET_CURRENT_POS,
     io_uring_cqe_seen,
     io_uring_get_sqe,
     io_uring_peek_cqe,
@@ -114,8 +115,19 @@ class _ProactorSubmit:
         self._cache: ProatorCache = cache
         self._unsubmitted: list[tuple[int, KernelRequest]] = []
 
-    def recv(self, request: RecvRequest, user_data: int, flags: int = 0) -> Self:
+    def _get_sqe(self) -> Any:
         sqe = io_uring_get_sqe(self._iouring)
+        if sqe is None:
+            # submission queue is full: flush the prepared SQEs to the kernel
+            # to free up slots, then retry
+            io_uring_submit(self._iouring)
+            sqe = io_uring_get_sqe(self._iouring)
+            if sqe is None:
+                raise RuntimeError("io_uring submission queue is full")
+        return sqe
+
+    def recv(self, request: RecvRequest, user_data: int, flags: int = 0) -> Self:
+        sqe = self._get_sqe()
         io_uring_prep_recv(sqe, request)
         io_uring_sqe_set_data64(sqe, user_data)
         if flags:
@@ -124,7 +136,7 @@ class _ProactorSubmit:
         return self
 
     def read(self, request: ReadRequest, user_data: int, flags: int = 0) -> Self:
-        sqe = io_uring_get_sqe(self._iouring)
+        sqe = self._get_sqe()
         io_uring_prep_read(sqe, request)
         io_uring_sqe_set_data64(sqe, user_data)
         if flags:
@@ -133,7 +145,7 @@ class _ProactorSubmit:
         return self
 
     def recvfrom(self, request: RecvFromRequest, user_data: int, flags: int = 0) -> Self:
-        sqe = io_uring_get_sqe(self._iouring)
+        sqe = self._get_sqe()
         io_uring_prep_recvfrom(sqe, request)
         io_uring_sqe_set_data64(sqe, user_data)
         if flags:
@@ -142,7 +154,7 @@ class _ProactorSubmit:
         return self
 
     def sendto(self, request: SendToRequest, user_data: int, flags: int = 0) -> Self:
-        sqe = io_uring_get_sqe(self._iouring)
+        sqe = self._get_sqe()
         io_uring_prep_sendto(sqe, request)
         io_uring_sqe_set_data64(sqe, user_data)
         if flags:
@@ -151,7 +163,7 @@ class _ProactorSubmit:
         return self
 
     def send(self, request: SendRequest, user_data: int, flags: int = 0) -> Self:
-        sqe = io_uring_get_sqe(self._iouring)
+        sqe = self._get_sqe()
         io_uring_prep_send(sqe, request)
         io_uring_sqe_set_data64(sqe, user_data)
         if flags:
@@ -160,7 +172,7 @@ class _ProactorSubmit:
         return self
 
     def write(self, request: WriteRequest, user_data: int, flags: int = 0) -> Self:
-        sqe = io_uring_get_sqe(self._iouring)
+        sqe = self._get_sqe()
         io_uring_prep_write(sqe, request)
         io_uring_sqe_set_data64(sqe, user_data)
         if flags:
@@ -169,7 +181,7 @@ class _ProactorSubmit:
         return self
 
     def accept(self, request: AcceptRequest, user_data: int, flags: int = 0) -> Self:
-        sqe = io_uring_get_sqe(self._iouring)
+        sqe = self._get_sqe()
         io_uring_prep_accept(sqe, request)
         io_uring_sqe_set_data64(sqe, user_data)
         if flags:
@@ -178,7 +190,7 @@ class _ProactorSubmit:
         return self
 
     def connect(self, request: ConnectRequest, user_data: int, flags: int = 0) -> Self:
-        sqe = io_uring_get_sqe(self._iouring)
+        sqe = self._get_sqe()
         io_uring_prep_connect(sqe, request)
         io_uring_sqe_set_data64(sqe, user_data)
         if flags:
@@ -187,7 +199,7 @@ class _ProactorSubmit:
         return self
 
     def splice(self, request: SpliceRequest, user_data: int, flags: int = 0) -> Self:
-        sqe = io_uring_get_sqe(self._iouring)
+        sqe = self._get_sqe()
         io_uring_prep_splice(sqe, request)
         io_uring_sqe_set_data64(sqe, user_data)
         if flags:
@@ -196,7 +208,7 @@ class _ProactorSubmit:
         return self
 
     def cancel(self, request: Cancel64Request, user_data: int, flags: int = 0) -> Self:
-        sqe = io_uring_get_sqe(self._iouring)
+        sqe = self._get_sqe()
         io_uring_prep_cancel64(sqe, request)
         io_uring_sqe_set_data64(sqe, user_data)
         if flags:
@@ -205,7 +217,7 @@ class _ProactorSubmit:
         return self
 
     def poll_add(self, request: PollAddRequest, user_data: int, flags: int = 0) -> Self:
-        sqe = io_uring_get_sqe(self._iouring)
+        sqe = self._get_sqe()
         io_uring_prep_poll_add(sqe, request)
         io_uring_sqe_set_data64(sqe, user_data)
         if flags:
@@ -226,6 +238,7 @@ class IoUringProactor:
     def __init__(self, entries: int = DEFAULT_ENTRIES, flags: int = 0):
         self._loop: events.AbstractEventLoop | None = None
         self._results: list[futures.Future[Any]] = []
+        self._iouring: IoUring | None = None
         ring = new_io_uring()
         io_uring_queue_init(entries, ring, flags)
 
@@ -268,7 +281,7 @@ class IoUringProactor:
             self.submitter.recv(request, user_data).submit(op=op, fut=fut)
             return fut
         else:
-            request = ReadRequest(file=conn, buffer=buf, offset=0)
+            request = ReadRequest(file=conn, buffer=buf, offset=OFFSET_CURRENT_POS)
             op = ReadOperation(file=conn, buffer=buf, user_data=user_data)
             fut = _IoUringFuture(self, op, loop=self._loop)
             self.submitter.read(request, user_data).submit(op=op, fut=fut)
@@ -283,7 +296,7 @@ class IoUringProactor:
             self.submitter.recv(request, user_data).submit(op=op, fut=fut)
             return fut
         else:
-            request = ReadRequest(file=conn, buffer=buf, offset=0)
+            request = ReadRequest(file=conn, buffer=buf, offset=OFFSET_CURRENT_POS)
             op = ReadIntoOperation(file=conn, buffer=buf, user_data=user_data)
             fut = _IoUringFuture(self, op, loop=self._loop)
             self.submitter.read(request, user_data).submit(op=op, fut=fut)
@@ -329,8 +342,8 @@ class IoUringProactor:
             self.submitter.send(request, user_data).submit(op=op, fut=fut)
             return fut
         else:
-            request = WriteRequest(file=conn, buffer=buf_view, offset=0)
-            op = WriteOperation(file=conn, buffer=buf_view, offset=0, user_data=user_data)
+            request = WriteRequest(file=conn, buffer=buf_view, offset=OFFSET_CURRENT_POS)
+            op = WriteOperation(file=conn, buffer=buf_view, offset=OFFSET_CURRENT_POS, user_data=user_data)
             fut = _IoUringFuture(self, op, loop=self._loop)
             self.submitter.write(request, user_data).submit(op=op, fut=fut)
             return fut
@@ -411,7 +424,16 @@ class IoUringProactor:
 
     def _poll(self, timeout: float | None = None):
         if timeout is None:
-            cqe = io_uring_wait_cqe(self._iouring)
+            while True:
+                try:
+                    cqe = io_uring_wait_cqe(self._iouring)
+                    break
+                except OSError as e:
+                    # interrupted by a signal: retry; a raised signal handler
+                    # exception (e.g. KeyboardInterrupt) still propagates
+                    if e.errno == errno.EINTR:
+                        continue
+                    raise
             self._handle_cqe(cqe)
             io_uring_cqe_seen(self._iouring, cqe)
 
@@ -423,9 +445,11 @@ class IoUringProactor:
             try:
                 cqe = io_uring_wait_cqe_timeout(self._iouring, ktspec)
             except OSError as e:
-                if e.errno == errno.ETIME:
+                # treat a signal interruption like a timeout: the event loop
+                # recalculates the timeout and calls select again
+                if e.errno in (errno.ETIME, errno.EINTR):
                     return
-                raise e
+                raise
             self._handle_cqe(cqe)
             io_uring_cqe_seen(self._iouring, cqe)
 
@@ -442,7 +466,9 @@ class IoUringProactor:
 
     def _stop_serving(self, obj: Any):
         self._stopped_serving.add(obj)
-        for pending in self._cache.values():
+        # iterate over a copy: fut.cancel() submits a cancel SQE, which
+        # registers a new cache entry and would break dict iteration
+        for pending in list(self._cache.values()):
             op = pending.operation
             fut = pending.future
             if op.get_file_obj() in self._stopped_serving and fut and not fut.done():
@@ -478,7 +504,7 @@ class IoUringProactor:
                 self._run_operation(cqe, op, fut)
         # if fut is None, it means it from cancelation
         elif cqe.res < 0:
-            if self._loop is None or cqe.res == -2 and op.all_seen():
+            if self._loop is None or cqe.res == -errno.ENOENT and op.all_seen():
                 # if  target cqe completed before the cancelation, ignores the cancelation "not found"
                 # TODO: if the cancelation cqe returns earlier than target cqe, avoid it shows error message.
                 return


### PR DESCRIPTION
## Summary

- handle partial sends, interrupted polling, full submission queues, and cancellation safely
- use current file offsets for io_uring file I/O and validate kernel/ring initialization
- make failed initialization and child-watcher cleanup safe

## Why

Several edge cases could resend data, operate at the wrong file offset, mutate pending operations during iteration, or leave partially initialized resources in an invalid state.

## Impact

Event-loop I/O and cleanup behave reliably under partial progress, signals, queue pressure, and initialization failures.

## Validation

- `uv run pytest -q` — 13 passed
- `uv run ruff check uringloop tests`
- `git diff --check main...HEAD`
