### PR TITLE
fix: support Python 3.14 subprocess handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,12 @@ pip install uringloop
 
 ## Quick Start
 
-Set the event loop policy with asyncio.set_event_loop_policy(IouringProactorEventLoopPolicy()) to use the io_uring-based event loop.
+Pass the loop factory to `asyncio.run` to use the io_uring-based event loop:
 
 ```python
 import asyncio
 
-from uringloop import IouringProactorEventLoopPolicy
-
-
-asyncio.set_event_loop_policy(IouringProactorEventLoopPolicy())
+from uringloop import IouringProactorEventLoop
 
 
 async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
@@ -113,7 +110,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(main(), loop_factory=IouringProactorEventLoop)
 
 ```
 
@@ -122,11 +119,22 @@ the result would looks like
 ```console
 Serving on ('127.0.0.1', 8888)
 Send: 'Hello, World!'
-Connection from ('0.0.0.0', 0)
+Connection from ('127.0.0.1', 52306)
 Received: Hello, World!
 Received: 'Hello, World!'
 Closing connection
-Connection with ('0.0.0.0', 0) closed
+Connection with ('127.0.0.1', 52306) closed
+```
+
+An event loop policy is also available for code that still uses the (deprecated since Python 3.14) policy system:
+
+```python
+import asyncio
+
+from uringloop import IouringProactorEventLoopPolicy
+
+asyncio.set_event_loop_policy(IouringProactorEventLoopPolicy())
+asyncio.run(main())
 ```
 
 ## Contributing

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -1,0 +1,24 @@
+import asyncio.unix_events
+import warnings
+
+import pytest
+
+from uringloop.loop import IouringProactorEventLoopPolicy
+
+
+@pytest.mark.skipif(
+    not hasattr(asyncio.unix_events, "AbstractChildWatcher"),
+    reason="the child-watcher API was removed in Python 3.14",
+)
+def test_policy_preserves_child_watcher_api():
+    policy = IouringProactorEventLoopPolicy()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        watcher = policy.get_child_watcher()
+
+    assert isinstance(watcher, asyncio.unix_events.AbstractChildWatcher)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        policy.set_child_watcher(None)

--- a/uringloop/loop.py
+++ b/uringloop/loop.py
@@ -5,8 +5,7 @@ import io
 import os
 import socket
 import stat
-from typing import Any, Callable, cast
-import warnings
+from typing import Any, cast
 
 from uringloop.lib import POLLERR, POLLHUP, POLLIN
 from uringloop.log import logger
@@ -193,64 +192,31 @@ class IouringProactorEventLoop(proactor_events.BaseProactorEventLoop):
     async def _make_subprocess_transport(
         self, protocol, args, shell, stdin, stdout, stderr, bufsize: int, extra=None, **kwargs
     ):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            watcher = events.get_child_watcher()
-
-        with watcher:
-            if not watcher.is_active():
-                # Check early.
-                # Raising exception before process creation
-                # prevents subprocess execution if the watcher
-                # is not ready to handle it.
-                raise RuntimeError("asyncio.get_child_watcher() is not activated, subprocess support is not installed.")
-            waiter = self.create_future()
-            transp = unix_events._UnixSubprocessTransport(   # type: ignore[reportPrivateUsage]
-                self, protocol, args, shell, stdin, stdout, stderr, bufsize, waiter=waiter, extra=extra, **kwargs
-            )
-            watcher.add_child_handler(cast(int, transp.get_pid()), self._child_watcher_callback, transp)
-            try:
-                await waiter
-            except (SystemExit, KeyboardInterrupt):
-                raise
-            except BaseException:
-                transp.close()
-                await transp._wait()
-                raise
+        waiter = self.create_future()
+        transp = unix_events._UnixSubprocessTransport(   # type: ignore[reportPrivateUsage]
+            self, protocol, args, shell, stdin, stdout, stderr, bufsize, waiter=waiter, extra=extra, **kwargs
+        )
+        self._watch_child(cast(int, transp.get_pid()), transp)
+        try:
+            await waiter
+        except (SystemExit, KeyboardInterrupt):
+            raise
+        except BaseException:
+            transp.close()
+            await transp._wait()
+            raise
 
         return transp
 
-    def _make_write_pipe_transport(self, sock, protocol, waiter=None, extra=None):
-        return _IouringWritePipeTransport(self, sock, protocol, waiter, extra)
+    def _watch_child(self, pid: int, transp: "unix_events._UnixSubprocessTransport"):   # type: ignore[reportPrivateUsage]
+        """Reap the child through a pidfd polled by io_uring.
 
-    def _child_watcher_callback(self, pid: int, returncode: int, transp: unix_events._UnixSubprocessTransport):   # type: ignore[reportPrivateUsage]
-        self.call_soon_threadsafe(transp._process_exited, returncode)
-
-
-class UnixProactorPidfdChildWatcher(unix_events.AbstractChildWatcher):
-    """Child watcher implementation using io uring and Linux's pid file descriptors."""
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        pass
-
-    def is_active(self):
-        return True
-
-    def close(self):
-        pass
-
-    def attach_loop(self, loop: events.AbstractEventLoop | None):
-        pass
-
-    def add_child_handler(self, pid: int, callback: Callable[[int, int, *tuple[Any, ...]], Any], *args: tuple[Any, ...]):
-        loop = events.get_running_loop()
+        This replaces the child watcher API, which was removed in Python 3.14.
+        """
         pidfd = os.pidfd_open(pid)
-        fut: futures.Future[int] = cast(IoUringProactor, loop._proactor).poll_add(pidfd, POLLIN)   # type: ignore[reportPrivateUsage]
+        fut: futures.Future[int] = self._proactor.poll_add(pidfd, POLLIN)
 
-        def _do_wait(fut: futures.Future[int]):
+        def _child_exited(fut: futures.Future[int]):
             try:
                 if fut.cancelled():
                     # the poll was cancelled (e.g. loop shutdown) so the child
@@ -266,55 +232,21 @@ class UnixProactorPidfdChildWatcher(unix_events.AbstractChildWatcher):
             finally:
                 os.close(pidfd)
 
-            callback(pid, returncode, *args)
+            self.call_soon(transp._process_exited, returncode)  # type: ignore[reportPrivateUsage]
 
-        fut.add_done_callback(_do_wait)
+        fut.add_done_callback(_child_exited)
 
-    def remove_child_handler(self, pid: int):
-        # asyncio never calls remove_child_handler() !!!
-        # The method is no-op but is implemented because
-        # abstract base classes require it.
-        return True
+    def _make_write_pipe_transport(self, sock, protocol, waiter=None, extra=None):
+        return _IouringWritePipeTransport(self, sock, protocol, waiter, extra)
 
 
-class IouringProactorEventLoopPolicy(events.BaseDefaultEventLoopPolicy):
+# Preserve the child-watcher methods on Python 3.12 and 3.13 by using the Unix
+# policy while it exists. Python 3.14 removed that policy and renamed the
+# generic base, so fall back to whichever generic name is available there.
+_BaseDefaultEventLoopPolicy: type[Any] = getattr(unix_events, "_UnixDefaultEventLoopPolicy", None) or (
+    getattr(events, "BaseDefaultEventLoopPolicy", None) or getattr(events, "_BaseDefaultEventLoopPolicy")
+)
+
+
+class IouringProactorEventLoopPolicy(_BaseDefaultEventLoopPolicy):
     _loop_factory = IouringProactorEventLoop
-
-    def __init__(self):
-        super().__init__()
-        self._watcher: unix_events.AbstractChildWatcher | None = None
-
-    def _init_watcher(self):
-        with events._lock:
-            if self._watcher is None:
-                self._watcher = UnixProactorPidfdChildWatcher()
-
-    def get_child_watcher(self):
-        """Get the watcher for child processes.
-
-        If not yet set, a ThreadedChildWatcher object is automatically created.
-        """
-        if self._watcher is None:
-            self._init_watcher()
-
-        warnings._deprecated(
-            "get_child_watcher",
-            "{name!r} is deprecated as of Python 3.12 and will be removed in Python {remove}.",
-            remove=(3, 14),
-        )
-        return self._watcher
-
-    def set_child_watcher(self, watcher: unix_events.AbstractChildWatcher | None):
-        """Set the watcher for child processes."""
-
-        assert watcher is None or isinstance(watcher, unix_events.AbstractChildWatcher)
-
-        if self._watcher is not None:
-            self._watcher.close()
-
-        self._watcher = watcher
-        warnings._deprecated(
-            "set_child_watcher",
-            "{name!r} is deprecated as of Python 3.12 and will be removed in Python {remove}.",
-            remove=(3, 14),
-        )


### PR DESCRIPTION
## Summary

- move subprocess reaping into the io_uring event loop using pidfds
- avoid the child-watcher API removed in Python 3.14
- preserve child-watcher policy methods on Python 3.12 and 3.13
- document the modern `asyncio.run(..., loop_factory=...)` setup

## Why

Python 3.14 removed asyncio's child-watcher API, so the previous subprocess implementation and event-loop policy could no longer be defined there.

## Impact

Subprocess support uses the loop's native pidfd polling path across supported Python versions, while older policy-based integrations remain compatible.

## Validation

- `uv run pytest -q` — 14 passed on Python 3.12
- `uv run ruff check uringloop tests`
- `git diff --check main...HEAD`
